### PR TITLE
Added special keyboards to manual entry screens

### DIFF
--- a/FieldTheBern/Views/Base.lproj/Main.storyboard
+++ b/FieldTheBern/Views/Base.lproj/Main.storyboard
@@ -2635,7 +2635,7 @@
                                                     <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <fontDescription key="fontDescription" name="Lato-Medium" family="Lato" pointSize="18"/>
-                                                    <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" spellCheckingType="no" returnKeyType="next"/>
+                                                    <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress" returnKeyType="next"/>
                                                 </textField>
                                             </subviews>
                                             <animations/>
@@ -2684,7 +2684,7 @@
                                                     <color key="tintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     <fontDescription key="fontDescription" name="Lato-Medium" family="Lato" pointSize="18"/>
-                                                    <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" spellCheckingType="no" returnKeyType="done"/>
+                                                    <textInputTraits key="textInputTraits" autocapitalizationType="words" autocorrectionType="no" spellCheckingType="no" keyboardType="phonePad" returnKeyType="done"/>
                                                 </textField>
                                             </subviews>
                                             <animations/>
@@ -6273,7 +6273,7 @@ useful talking points.</string>
             <objects>
                 <collectionViewController storyboardIdentifier="HomeItemsController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="mzc-2t-CbK" customClass="HomeItemsViewController" customModule="FieldTheBern" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" id="yh0-3P-oQN">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="640"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
                         <color key="backgroundColor" red="0.21960784310000001" green="0.56078431370000004" blue="0.85490196080000003" alpha="1" colorSpace="calibratedRGB"/>
@@ -6325,7 +6325,7 @@ useful talking points.</string>
                             </collectionViewCell>
                         </cells>
                         <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="CollectionActivityHeader" id="oax-Y2-IU3">
-                            <rect key="frame" x="0.0" y="64" width="600" height="50"/>
+                            <rect key="frame" x="0.0" y="64" width="400" height="50"/>
                             <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="gdA-h1-HhE">
@@ -6680,7 +6680,7 @@ useful talking points.</string>
             <objects>
                 <collectionViewController storyboardIdentifier="ItemsController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="U4N-rO-VAS" customClass="ItemsViewController" customModule="FieldTheBern" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" id="RpP-eH-y61">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="400" height="640"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <animations/>
                         <color key="backgroundColor" red="0.21960784310000001" green="0.56078431370000004" blue="0.85490196080000003" alpha="1" colorSpace="calibratedRGB"/>
@@ -8965,7 +8965,7 @@ useful talking points.</string>
     <inferredMetricsTieBreakers>
         <segue reference="15R-T0-4T5"/>
         <segue reference="3nY-LF-DGD"/>
-        <segue reference="Rbd-US-3DY"/>
+        <segue reference="Y1h-lb-cnM"/>
         <segue reference="ovj-FK-nQJ"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
Added special keyboards to manual entry screens. Specifically, on
PersonDetailsVC, I added the phone pad keyboard when entering phones,
and the email keyboard when entering emails.

Previous changes were accidentally added to development directly. They are commit 206 (2c74311dd66b72d1e851fb3f5fd9d12eda247fd8) and 207 (1b5b5ac2315f850251de89704a3a89219b5d8db1). Apologies.  
