### PR TITLE
Fix FB SDK deprecations deprecations

### DIFF
--- a/FieldTheBern/Controllers/ProfileViewController.swift
+++ b/FieldTheBern/Controllers/ProfileViewController.swift
@@ -321,7 +321,8 @@ class ProfileViewController: UIViewController, UITableViewDelegate, UITableViewD
     func showFacebookInviteDialog() {
         let content: FBSDKAppInviteContent = FBSDKAppInviteContent()
         content.appLinkURL = NSURL(string: "https://fb.me/835938513187372")
-        FBSDKAppInviteDialog.showWithContent(content, delegate: self)
+        FBSDKAppInviteDialog.showFromViewController(self, withContent: content, delegate: self)
+//        FBSDKAppInviteDialog.showWithContent(content, delegate: self)
     }
     
     func composeTextMessage() {

--- a/FieldTheBern/Controllers/SignInViewController.swift
+++ b/FieldTheBern/Controllers/SignInViewController.swift
@@ -127,7 +127,7 @@ class SignInViewController: UIViewController, UITextFieldDelegate {
         
         let login: FBSDKLoginManager = FBSDKLoginManager()
         login.loginBehavior = FBSDKLoginBehavior.Native
-        login.logInWithReadPermissions(["public_profile", "email", "user_friends"], handler: { (result: FBSDKLoginManagerLoginResult!, error: NSError!) -> Void in
+        login.logInWithReadPermissions(["public_profile", "email", "user_friends"], fromViewController: self, handler: { (result: FBSDKLoginManagerLoginResult!, error: NSError!) -> Void in
             self.facebookButton.titleLabel?.layer.opacity = 1
             self.facebookSpinner.stopAnimating()
             


### PR DESCRIPTION
Update FBSDKInviteDialog and loginWithReadPermissions to get rid of
deprecations.
