### PR TITLE
Removed unnecessary alert popup

### DIFF
--- a/FieldTheBern/Controllers/CanvassViewController.swift
+++ b/FieldTheBern/Controllers/CanvassViewController.swift
@@ -742,11 +742,6 @@ class CanvassViewController: UIViewController, CLLocationManagerDelegate, MKMapV
     // MARK: - Error Handling
     
     func handleError(error: APIError) {
-        let errorTitle = error.errorTitle
-        let errorMessage = error.errorDescription
-        
-        let alert = UIAlertController.errorAlertControllerWithTitle(errorTitle, message: errorMessage)
-        alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: nil))
-        self.presentViewController(alert, animated: true, completion: nil)
+        NSLog("\(error.errorTitle) - \(error.errorDescription)");
     }
 }


### PR DESCRIPTION
The user has no ability to retry, so the alert is just interrupting the user for no good reason. NSLog it instead

Will track down the cause later

Resolves issue https://github.com/Bernie-2016/fieldthebern-ios/issues/88